### PR TITLE
v1.0.0 -rev(n) Snomed US edition parameters

### DIFF
--- a/fsh/config.yaml
+++ b/fsh/config.yaml
@@ -35,6 +35,7 @@ dependencies:
   hl7.fhir.us.davinci-hrex: 0.2.0
 parameters:
   show-inherited-invariants: false
+  path-expansion-params: expansion-params.json
 copyrightYear: 2020+
 releaseLabel: CI Build
 jurisdiction: urn:iso:std:iso:3166#US

--- a/input/expansion-params.json
+++ b/input/expansion-params.json
@@ -1,0 +1,8 @@
+{
+  "resourceType" : "Parameters",
+  "id" : "exp-params",
+  "parameter" : [{
+     "name" : "system-version",
+     "valueUri" : "http://snomed.info/sct|http://snomed.info/sct/731000124108"
+}]
+}


### PR DESCRIPTION
in input/expansion-params.json. referenced from _config.yaml